### PR TITLE
Add browser-friendly entry point

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Prompt Engineering Trainer</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+  <div id="root"></div>
+  <script type="module">
+    import React from 'https://esm.sh/react';
+    import ReactDOM from 'https://esm.sh/react-dom/client';
+    import PromptTrainerApp from './main.js';
+    ReactDOM.createRoot(document.getElementById('root')).render(
+      React.createElement(PromptTrainerApp)
+    );
+  </script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useContext, createContext } from 'react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, BarChart, Bar, ResponsiveContainer } from 'recharts';
-import { Trophy, Clock, Target, Brain, User, Settings, BookOpen, Play, CheckCircle, AlertCircle, Star, Award, TrendingUp, Users, Zap } from 'lucide-react';
+import React, { useState, useEffect, useContext, createContext } from 'https://esm.sh/react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, BarChart, Bar, ResponsiveContainer } from 'https://esm.sh/recharts';
+import { Trophy, Clock, Target, Brain, User, Settings, BookOpen, Play, CheckCircle, AlertCircle, Star, Award, TrendingUp, Users, Zap } from 'https://esm.sh/lucide-react';
 
 // Mock data for demonstration
 const mockUser = {


### PR DESCRIPTION
## Summary
- add `index.html` that loads React components from CDN
- update `main.js` imports to also use CDN modules so it can run in the browser

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_68728b63ee808328b1181a1c4c2243e7